### PR TITLE
Improve performance of `useFittedPagination`

### DIFF
--- a/src/app/(invoices)/[type]/[number]/pdf/route.ts
+++ b/src/app/(invoices)/[type]/[number]/pdf/route.ts
@@ -76,7 +76,9 @@ async function generatePDF(url: string) {
   await page.goto(url)
 
   // Give the page time to load
-  await page.waitForSelector('[data-pdf-state="ready"]')
+  await page.waitForSelector('[data-pdf-state="ready"]', {
+    timeout: 2 * 60 * 1000, // 2 minutes
+  })
   let pdfBuffer = await page.pdf({ printBackground: true, format: 'A4', preferCSSPageSize: true })
 
   await browser.close()


### PR DESCRIPTION
This PR improves the performances of the `useFittedPagination` hook.

Instead of trying every item, and moving 1 item at a time to the next page, this uses a binary
search approach where we first try all items, then half of it. If it doesn't fit use the half of
that, if it did fit, try to use more items.

Visually this could look like this:


```
Total items: 50

min=0, max=50, pivot=25      [0                              50]
... 25 doesn't fit
min=0, max=25, pivot=12      [0                25]
... 12 does fit
min=12, max=25, pivot=18            [12        25]
... 18 doesn't fit
min=12, max=18, pivot=15            [12     18]
... 15 does fit
min=15, max=18, pivot=16              [15   18]
... 16 does fit
min=16, max=18, pivot=17               [16  18]
... 17 doesn't fit
min=16, max=16, pivot=16               [16]

16 items on this page.
```
