### PR TITLE
add backup invoices feature to account page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@heroicons/react": "^2.0.18",
         "@tailwindcss/forms": "^0.5.6",
         "@tailwindcss/typography": "^0.5.10",
+        "archiver": "^6.0.1",
         "autoprefixer": "^10.4.15",
         "case": "^1.6.3",
         "date-fns": "^2.30.0",
@@ -2569,6 +2570,76 @@
         "node": ">= 8"
       }
     },
+    "node_modules/archiver": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-6.0.1.tgz",
+      "integrity": "sha512-CXGy4poOLBKptiZH//VlWdFuUC1RESbdZjGjILwBuZ73P7WkAUN0htfSfBq/7k6FRFlpu7bg4JOkj1vU9G6jcQ==",
+      "dependencies": {
+        "archiver-utils": "^4.0.1",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^5.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-4.0.1.tgz",
+      "integrity": "sha512-Q4Q99idbvzmgCTEAAhi32BkOyq8iVI5EwdO0PmBDSGIzzjYNdcFn7Q7k3OzbLy4kLUPXfJtG6fO2RjftXbobBg==",
+      "dependencies": {
+        "glob": "^8.0.0",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -2714,6 +2785,11 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
       "dev": true
+    },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -3326,6 +3402,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-5.0.1.tgz",
+      "integrity": "sha512-MPh//1cERdLtqwO3pOFLeXtpuai0Y2WCd5AhtKxznqM7WtaMYaOEMSgn45d9D10sIHSfIKE603HlOp8OPGrvag==",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^5.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3336,6 +3426,11 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cosmiconfig": {
       "version": "8.3.5",
@@ -3360,6 +3455,29 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-5.0.0.tgz",
+      "integrity": "sha512-B0EPa1UK+qnpBZpG+7FgPCu0J2ETLpXq09o9BkLkEAhdB6Z61Qo4pJ3JYu0c+Qi+/SAL7QThqnzS06pmSSyZaw==",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/create-jest": {
@@ -7156,6 +7274,49 @@
         "node": ">=13"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8249,6 +8410,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -8504,6 +8670,46 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -8744,6 +8950,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -8982,6 +9207,14 @@
       "dependencies": {
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -10004,6 +10237,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-5.0.1.tgz",
+      "integrity": "sha512-UfZ0oa0C8LI58wJ+moL46BDIMgCQbnsb+2PoiJYtonhBsMh2bq1eRBVkvjfVsqbEHd9/EgKPUuL9saSSsec8OA==",
+      "dependencies": {
+        "archiver-utils": "^4.0.1",
+        "compress-commons": "^5.0.1",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "@heroicons/react": "^2.0.18",
     "@tailwindcss/forms": "^0.5.6",
     "@tailwindcss/typography": "^0.5.10",
+    "@types/archiver": "^5.3.2",
+    "archiver": "^6.0.1",
     "autoprefixer": "^10.4.15",
     "case": "^1.6.3",
     "date-fns": "^2.30.0",

--- a/src/app/(records)/[type]/[number]/components.tsx
+++ b/src/app/(records)/[type]/[number]/components.tsx
@@ -2,7 +2,6 @@
 
 import { EyeIcon } from '@heroicons/react/24/outline'
 import { format, formatISO9075, parseISO } from 'date-fns'
-// @ts-expect-error
 import estreePlugin from 'prettier/plugins/estree'
 import tsPlugin from 'prettier/plugins/typescript'
 import * as prettier from 'prettier/standalone'

--- a/src/app/accounts/[id]/backup/records/route.ts
+++ b/src/app/accounts/[id]/backup/records/route.ts
@@ -1,0 +1,90 @@
+import Archiver from 'archiver'
+import { format } from 'date-fns'
+import fs from 'fs'
+import { redirect } from 'next/navigation'
+import { tmpdir } from 'os'
+import puppeteer from 'puppeteer'
+import { records } from '~/data'
+import { config } from '~/domain/configuration/configuration'
+import { languageToLocale } from '~/utils/language-to-locale'
+import { render } from '~/utils/tl'
+
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+  // TODO: Don't do this, stream directly
+  let tmpFileName = `${tmpdir()}/simple-invoice-backup.zip`
+  let stream = fs.createWriteStream(tmpFileName)
+
+  // TODO: Filter records by account
+  let myRecords = records
+
+  if (myRecords.length <= 0) {
+    return redirect(`/`)
+  }
+
+  let baseURL = `http://${request.headers.get('host')}/{type}/{number}/raw`
+
+  let zip = Archiver('zip')
+
+  // Send the file to the page output.
+  zip.pipe(stream)
+
+  for (let [file, buffer] of await generatePDFs(
+    myRecords.map((record) => {
+      let { filename: filenameTemplate, folder: folderTemplate } = config()[record.type].pdf
+      let folder = render(folderTemplate, record, {
+        locale: languageToLocale(record.client.language),
+      })
+      let filename = render(filenameTemplate, record, {
+        locale: languageToLocale(record.client.language),
+      })
+      let url = baseURL.replace('{type}', record.type).replace('{number}', record.number)
+
+      return [`${folder}/${filename}`, url] as [string, string]
+    }),
+  )) {
+    zip.append(buffer, { name: file })
+  }
+
+  await zip.finalize()
+  await new Promise((r) => setTimeout(r, 100))
+
+  let response = new Response(fs.readFileSync(tmpFileName), { status: 200 })
+  response.headers.set('Content-Type', 'application/zip')
+  response.headers.set(
+    'Content-disposition',
+    `attachment; filename=backup-${format(new Date(), 'yyyy-MM-dd')}.zip`,
+  )
+  fs.unlinkSync(tmpFileName)
+
+  return response
+}
+
+async function generatePDFs(urls: [filename: string, url: string][]) {
+  let browser = await puppeteer.launch({ headless: 'new' })
+
+  let buffers = await Promise.all(
+    urls.map(async ([filename, url]) => {
+      let page = await browser.newPage()
+
+      await page.goto(url)
+
+      // Give the page time to load
+      await page.waitForSelector('[data-pdf-state="ready"]', {
+        timeout: 2 * 60 * 1000, // 2 minutes
+      })
+
+      return [
+        filename,
+        await page.pdf({
+          printBackground: true,
+          format: 'A4',
+          preferCSSPageSize: true,
+        }),
+      ] as const
+    }),
+  )
+
+  await browser.close()
+
+  return buffers
+}

--- a/src/app/accounts/[id]/backup/records/route.ts
+++ b/src/app/accounts/[id]/backup/records/route.ts
@@ -89,6 +89,8 @@ async function generatePDFs(urls: [filename: string, url: string][]) {
     urls.map(async ([filename, url]) => {
       let page = await browser.newPage()
 
+      page.setDefaultNavigationTimeout(0)
+
       await page.goto(url)
 
       // Give the page time to load

--- a/src/app/accounts/[id]/backup/records/route.ts
+++ b/src/app/accounts/[id]/backup/records/route.ts
@@ -1,19 +1,43 @@
 import Archiver from 'archiver'
 import { format } from 'date-fns'
-import fs from 'fs'
 import { redirect } from 'next/navigation'
-import { tmpdir } from 'os'
+import { Writable } from 'node:stream'
 import puppeteer from 'puppeteer'
 import { records } from '~/data'
 import { config } from '~/domain/configuration/configuration'
 import { languageToLocale } from '~/utils/language-to-locale'
 import { render } from '~/utils/tl'
 
-export async function GET(request: Request, { params }: { params: { id: string } }) {
-  // TODO: Don't do this, stream directly
-  let tmpFileName = `${tmpdir()}/simple-invoice-backup.zip`
-  let stream = fs.createWriteStream(tmpFileName)
+class BufferStream extends Writable {
+  private chunks: Uint8Array[] = []
+  private ready = false
+  private readyListeners: ((buffer: Buffer) => void)[] = []
 
+  _write(chunk: Uint8Array, encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+    this.chunks.push(chunk)
+    callback()
+  }
+
+  _final(callback: (error?: Error | null) => void) {
+    this.ready = true
+    for (let listener of this.readyListeners.splice(0)) {
+      listener(Buffer.concat(this.chunks))
+    }
+    callback()
+  }
+
+  buffer() {
+    if (this.ready) {
+      return Promise.resolve(Buffer.concat(this.chunks))
+    }
+
+    return new Promise<Buffer>((resolve) => {
+      this.readyListeners.push(resolve)
+    })
+  }
+}
+
+export async function GET(request: Request, { params }: { params: { id: string } }) {
   // TODO: Filter records by account
   let myRecords = records
 
@@ -26,7 +50,8 @@ export async function GET(request: Request, { params }: { params: { id: string }
   let zip = Archiver('zip')
 
   // Send the file to the page output.
-  zip.pipe(stream)
+  let bufferStream = new BufferStream()
+  zip.pipe(bufferStream)
 
   for (let [file, buffer] of await generatePDFs(
     myRecords.map((record) => {
@@ -46,15 +71,13 @@ export async function GET(request: Request, { params }: { params: { id: string }
   }
 
   await zip.finalize()
-  await new Promise((r) => setTimeout(r, 100))
 
-  let response = new Response(fs.readFileSync(tmpFileName), { status: 200 })
+  let response = new Response(await bufferStream.buffer(), { status: 200 })
   response.headers.set('Content-Type', 'application/zip')
   response.headers.set(
     'Content-disposition',
     `attachment; filename=backup-${format(new Date(), 'yyyy-MM-dd')}.zip`,
   )
-  fs.unlinkSync(tmpFileName)
 
   return response
 }

--- a/src/app/accounts/[id]/page.tsx
+++ b/src/app/accounts/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Address, formatAddress } from '~/ui/address/address'
 import { Avatar } from '~/ui/avatar'
 import { Card, CardBody, CardTitle, Field } from '~/ui/card'
 import { Classified } from '~/ui/classified'
+import { DownloadLink } from '~/ui/download-link'
 import { I18NProvider } from '~/ui/hooks/use-i18n'
 import { PaypalIcon } from '~/ui/icons/payment'
 import * as SocialIcons from '~/ui/icons/social'
@@ -105,14 +106,23 @@ export default async function Page({ params: { id } }: { params: { id: string } 
                   </span>
                 </div>
 
-                <Field title="iCal" variant="block">
-                  <a
-                    className="inline-flex items-center rounded-md border border-transparent bg-blue-600 px-3 py-2 text-sm font-medium leading-4 text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                    href={`webcal://${base}/accounts/${account.id}/ics`}
-                  >
-                    <CalendarIcon className="-ml-0.5 mr-2 h-4 w-4" aria-hidden="true" />
-                    Add to calendar
-                  </a>
+                <Field title="Actions" variant="block">
+                  <div className="flex gap-2">
+                    <a
+                      className="inline-flex items-center rounded-md border border-transparent bg-blue-600 px-3 py-2 font-sans text-sm font-medium leading-4 text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                      href={`webcal://${base}/accounts/${account.id}/ics`}
+                    >
+                      <CalendarIcon className="-ml-0.5 mr-2 h-4 w-4" aria-hidden="true" />
+                      Add to calendar
+                    </a>
+
+                    <DownloadLink
+                      className="inline-flex items-center rounded-md border border-transparent bg-blue-600 px-3 py-2 font-sans text-sm font-medium leading-4 text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                      href={`/accounts/${account.id}/backup/records`}
+                    >
+                      Download invoices
+                    </DownloadLink>
+                  </div>
                 </Field>
               </CardBody>
             </Card>

--- a/src/data/example.ts
+++ b/src/data/example.ts
@@ -47,6 +47,11 @@ configure({
        *  - For dates, you can use a format string, for example `{{quoteDate:dd-MM-yyyy}}`
        */
       filename: 'quote-{{number}}.pdf',
+
+      /**
+       * When creating a backup, the PDFs will be stored in this folder.
+       */
+      folder: 'quotes/{{status}}/{{quoteDate:yyyy-QQ}}',
     },
 
     mail: {
@@ -95,6 +100,11 @@ configure({
        *  - For dates, you can use a format string, for example `{{issueDate:dd-MM-yyyy}}`
        */
       filename: 'invoice-{{number}}.pdf',
+
+      /**
+       * When creating a backup, the PDFs will be stored in this folder.
+       */
+      folder: 'invoices/{{status}}/{{issueDate:yyyy-QQ}}',
     },
 
     mail: {
@@ -137,6 +147,11 @@ configure({
        *  - For dates, you can use a format string, for example `{{receiptDate:dd-MM-yyyy}}`
        */
       filename: 'receipt-{{number}}.pdf',
+
+      /**
+       * When creating a backup, the PDFs will be stored in this folder.
+       */
+      folder: 'receipts/{{status}}/{{invoice.issueDate:yyyy-QQ}}',
     },
 
     mail: {

--- a/src/domain/invoice/configuration.ts
+++ b/src/domain/invoice/configuration.ts
@@ -28,6 +28,11 @@ export type Configuration = {
      *  - For dates, you can use a format string, for example `{{issueDate:dd-MM-yyyy}}`
      */
     filename: string
+
+    /**
+     * When creating a backup, the PDFs will be stored in this folder.
+     */
+    folder: string
   }
 
   /**
@@ -43,6 +48,7 @@ export let defaultConfiguration: Configuration = {
   numberStrategy: new IncrementStrategy().next,
   pdf: {
     filename: 'invoice-{{number}}.pdf',
+    folder: 'invoices/{{status}}/{{issueDate:yyyy-QQ}}',
   },
   mail: {
     templates: [],

--- a/src/domain/quote/configuration.ts
+++ b/src/domain/quote/configuration.ts
@@ -29,6 +29,11 @@ export type Configuration = {
      *  - For dates, you can use a format string, for example `{{quoteDate:dd-MM-yyyy}}`
      */
     filename: string
+
+    /**
+     * When creating a backup, the PDFs will be stored in this folder.
+     */
+    folder: string
   }
 
   /**
@@ -44,6 +49,7 @@ export let defaultConfiguration: Configuration = {
   numberStrategy: new IncrementStrategy().next,
   pdf: {
     filename: 'quote-{{number}}.pdf',
+    folder: 'quotes/{{status}}/{{quoteDate:yyyy-QQ}}',
   },
   mail: {
     templates: [],

--- a/src/domain/receipt/configuration.ts
+++ b/src/domain/receipt/configuration.ts
@@ -13,6 +13,11 @@ export type Configuration = {
      *  - For dates, you can use a format string, for example `{{receiptDate:dd-MM-yyyy}}`
      */
     filename: string
+
+    /**
+     * When creating a backup, the PDFs will be stored in this folder.
+     */
+    folder: string
   }
 
   /**
@@ -26,6 +31,7 @@ export type Configuration = {
 export let defaultConfiguration: Configuration = {
   pdf: {
     filename: 'receipt-{{invoice.number}}.pdf',
+    folder: 'quotes/{{invoice.issueDate:yyyy-QQ}}',
   },
   mail: {
     templates: [],

--- a/src/ui/download-link.tsx
+++ b/src/ui/download-link.tsx
@@ -30,7 +30,19 @@ export function DownloadLink({
   }, [d, downloading])
 
   return (
-    <a onClick={() => setDownloading(true)} download {...props}>
+    <a
+      onClick={(e) => {
+        if (downloading) {
+          e.preventDefault()
+          return
+        }
+
+        setDownloading(true)
+      }}
+      aria-disabled={downloading}
+      download
+      {...props}
+    >
       {downloading ? (
         <ArrowPathIcon className="mr-2 h-4 w-4 animate-spin" />
       ) : (


### PR DESCRIPTION
This PR adds a little backup feature to download all the quotes / invoices / receipts right from your account.

You can also configure the folder structure in your data file:

```ts
configure({
  quote: {
    pdf: {
      filename: 'quote-{{number}}.pdf',
      folder: 'quotes/{{status}}/{{quoteDate:yyyy-QQ}}',
    },
  },

  invoice: {
    pdf: {
      filename: 'invoice-{{number}}.pdf',
      folder: 'invoices/{{status}}/{{issueDate:yyyy-QQ}}',
    },
  },

  receipt: {
    pdf: {
      filename: 'receipt-{{number}}.pdf',
      folder: 'receipts/{{status}}/{{invoice.issueDate:yyyy-QQ}}',
    },
  },
})
```

This is the default structure.
