### PR TITLE
Add internal notes on records

### DIFF
--- a/src/app/(records)/[type]/[number]/page.tsx
+++ b/src/app/(records)/[type]/[number]/page.tsx
@@ -1,5 +1,6 @@
 import { ExclamationTriangleIcon } from '@heroicons/react/20/solid'
-import { EyeIcon } from '@heroicons/react/24/outline'
+import { EyeIcon, LockClosedIcon } from '@heroicons/react/24/outline'
+import { compareAsc } from 'date-fns'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { transactions as allTransactions, me, records } from '~/data'
@@ -12,6 +13,7 @@ import { I18NProvider } from '~/ui/hooks/use-i18n'
 import { ActivityFeed } from '~/ui/invoice/activity-feed'
 import { AttachmentList } from '~/ui/invoice/attachment-list'
 import { Invoice as InvoicePreview } from '~/ui/invoice/design'
+import { Notes } from '~/ui/invoice/notes'
 import { total } from '~/ui/invoice/total'
 import { Money } from '~/ui/money'
 import { TransactionsTable } from '~/ui/transaction/table'
@@ -105,6 +107,25 @@ export default async function Invoice({
               <span className="text-sm font-medium text-gray-900 dark:text-gray-300">Activity</span>
               <ActivityFeed records={records} />
             </div>
+
+            {record.internal.notes.length > 0 && (
+              <div className="flex flex-col gap-4 rounded-lg bg-white p-4 shadow ring-1 ring-black/5 dark:bg-zinc-900 dark:text-gray-300">
+                <div className="flex items-center gap-2">
+                  <LockClosedIcon
+                    className="h-4 w-4 text-gray-600 dark:text-gray-300"
+                    aria-hidden="true"
+                  />
+                  <span className="text-sm font-medium text-gray-900 dark:text-gray-300">
+                    Internal notes
+                  </span>
+                </div>
+                <Notes
+                  notes={record.internal.notes.sort((a, z) => {
+                    return compareAsc(a.at, z.at)
+                  })}
+                />
+              </div>
+            )}
 
             {record.attachments.length > 0 && (
               <div className="flex flex-col gap-4 rounded-lg bg-white p-4 shadow ring-1 ring-black/5 dark:bg-zinc-900 dark:text-gray-300">

--- a/src/app/(records)/[type]/[number]/page.tsx
+++ b/src/app/(records)/[type]/[number]/page.tsx
@@ -1,6 +1,5 @@
 import { ExclamationTriangleIcon } from '@heroicons/react/20/solid'
 import { EyeIcon, LockClosedIcon } from '@heroicons/react/24/outline'
-import { compareAsc } from 'date-fns'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { transactions as allTransactions, me, records } from '~/data'
@@ -119,11 +118,7 @@ export default async function Invoice({
                     Internal notes
                   </span>
                 </div>
-                <Notes
-                  notes={record.internal.notes.sort((a, z) => {
-                    return compareAsc(a.at, z.at)
-                  })}
-                />
+                <Notes records={records} />
               </div>
             )}
 

--- a/src/data/example.ts
+++ b/src/data/example.ts
@@ -615,6 +615,28 @@ records.push(
     .build(),
 )
 
+// Single item invoice with internal notes
+records.push(
+  new InvoiceBuilder()
+    .account(me)
+    .client(Client2)
+    .issueDate(inThePast())
+    .item(new InvoiceItemBuilder().description('Item line #1').unitPrice(100_00).build())
+    .internal.note('This is an internal note that can be used for internal purposes only.', today())
+    .internal.note(
+      md`
+        This is _another_ note. It's **important** to know that this is a very important note because it contains markdown.
+
+        1. Even with list items
+        2. Such as these…
+      `,
+      nextDay(),
+    )
+    .send(nextDay())
+    .pay(nextDay())
+    .build(),
+)
+
 // Single item invoice, in the future
 records.push(
   new InvoiceBuilder()

--- a/src/domain/credit-note/credit-note.ts
+++ b/src/domain/credit-note/credit-note.ts
@@ -47,6 +47,11 @@ export let CreditNote = z.object({
       return Document
     }),
   ),
+
+  // Internal information, not visible to the client
+  internal: z.object({
+    notes: z.array(z.object({ value: z.string(), at: z.date() })),
+  }),
 })
 
 export type CreditNote = z.infer<typeof CreditNote>
@@ -61,6 +66,7 @@ export class CreditNoteBuilder {
   private _creditNoteDate: Date | null = null
   private _discounts: Discount[] = []
   private _attachments: Document[] = []
+  private _internalNotes: Invoice['internal']['notes'] = []
 
   private _events: Partial<Event>[] = []
 
@@ -81,6 +87,9 @@ export class CreditNoteBuilder {
       creditNoteDate: this._creditNoteDate,
       discounts: this._discounts,
       attachments: this._attachments,
+      internal: {
+        notes: this._internalNotes,
+      },
     })
 
     // Invert the values
@@ -167,5 +176,15 @@ export class CreditNoteBuilder {
   public attachment(attachment: Document): CreditNoteBuilder {
     this._attachments.push(attachment)
     return this
+  }
+
+  get internal() {
+    return {
+      note: (note: string, at: string | Date) => {
+        let parsedAt = typeof at === 'string' ? parseISO(at) : at
+        this._internalNotes.push({ value: note, at: parsedAt })
+        return this
+      },
+    }
   }
 }

--- a/src/domain/receipt/receipt.ts
+++ b/src/domain/receipt/receipt.ts
@@ -48,6 +48,11 @@ export let Receipt = z.object({
       return Document
     }),
   ),
+
+  // Internal information, not visible to the client
+  internal: z.object({
+    notes: z.array(z.object({ value: z.string(), at: z.date() })),
+  }),
 })
 
 export type Receipt = z.infer<typeof Receipt>
@@ -62,6 +67,7 @@ export class ReceiptBuilder {
   private _receiptDate: Date | null = null
   private _discounts: Discount[] = []
   private _attachments: Document[] = []
+  private _internalNotes: Receipt['internal']['notes'] = []
 
   private _events: Partial<Event>[] = []
 
@@ -82,6 +88,9 @@ export class ReceiptBuilder {
       receiptDate: this._receiptDate,
       discounts: this._discounts,
       attachments: this._attachments,
+      internal: {
+        notes: this._internalNotes,
+      },
     })
 
     for (let event of this._events) {
@@ -143,5 +152,15 @@ export class ReceiptBuilder {
   public attachment(attachment: Document): ReceiptBuilder {
     this._attachments.push(attachment)
     return this
+  }
+
+  get internal() {
+    return {
+      note: (note: string, at: string | Date) => {
+        let parsedAt = typeof at === 'string' ? parseISO(at) : at
+        this._internalNotes.push({ value: note, at: parsedAt })
+        return this
+      },
+    }
   }
 }

--- a/src/ui/invoice/notes.tsx
+++ b/src/ui/invoice/notes.tsx
@@ -1,26 +1,86 @@
 'use client'
 
-import { format, formatDistance } from 'date-fns'
+import { compareAsc, format, formatDistance } from 'date-fns'
+import { Fragment } from 'react'
+import type { Record } from '~/domain/record/record'
 import { useCurrentDate } from '~/ui/hooks/use-current-date'
+import { match } from '~/utils/match'
+import { classNames } from '../class-names'
+import { useRecord } from '../hooks/use-record'
+import { useRecordStacks } from '../hooks/use-record-stacks'
 import { Markdown } from '../markdown'
 
-export function Notes({ notes }: { notes: { value: string; at: Date }[] }) {
+export function Notes(props: React.PropsWithChildren<{ records: Record[] }>) {
+  let stacks = useRecordStacks()
+  let record = useRecord()
+  let records = (stacks[record.id] ?? []).map((id) => {
+    return props.records.find((e) => {
+      return e.id === id
+    })!
+  })
+
   let now = useCurrentDate()
+  let activeRecordIdx = stacks[record.id]?.indexOf(record.id) ?? -1
 
   return (
     <ul role="list" className="flex flex-col gap-4">
-      {notes.map((note, idx) => {
+      {records.map((record, idx) => {
         return (
-          <li key={idx} className="flex flex-col border-l-2 pl-2 dark:border-gray-200/25">
-            <time
-              title={format(note.at, 'PPPpp')}
-              dateTime={format(note.at, 'PPPpp')}
-              className="py-0.5 text-xs leading-5 text-gray-500 dark:text-gray-300"
+          <Fragment key={record.id}>
+            {records.length !== 1 && (
+              <li
+                className={classNames(
+                  'relative flex items-center text-sm',
+                  idx > activeRecordIdx && 'opacity-50 grayscale',
+                )}
+              >
+                <span className="whitespace-nowrap pr-3">
+                  {match(record.type, {
+                    quote: () => {
+                      return 'Quote'
+                    },
+                    invoice: () => {
+                      return 'Invoice'
+                    },
+                    'credit-note': () => {
+                      return 'Credit note'
+                    },
+                    receipt: () => {
+                      return 'Receipt'
+                    },
+                  })}{' '}
+                  (#{record.number})
+                </span>
+                <span className="h-px w-full bg-gray-200 dark:bg-zinc-600"></span>
+              </li>
+            )}
+            <ul
+              role="list"
+              className={classNames(
+                'relative flex flex-col gap-6',
+                idx > activeRecordIdx && 'opacity-50 grayscale',
+              )}
             >
-              {formatDistance(note.at, now, { addSuffix: true })}
-            </time>
-            <Markdown className="prose prose-sm dark:prose-invert">{note.value}</Markdown>
-          </li>
+              {record.internal.notes
+                .sort((a, z) => {
+                  return compareAsc(a.at, z.at)
+                })
+                .map((note, idx) => {
+                  return (
+                    <li key={idx} className="flex flex-col border-l-2 pl-2 dark:border-gray-200/25">
+                      <time
+                        title={format(note.at, 'PPPpp')}
+                        dateTime={format(note.at, 'PPPpp')}
+                        className="py-0.5 text-xs leading-5 text-gray-500 dark:text-gray-300"
+                      >
+                        {formatDistance(note.at, now, { addSuffix: true })}
+                      </time>
+                      <Markdown className="prose prose-sm dark:prose-invert">{note.value}</Markdown>
+                    </li>
+                  )
+                })}
+            </ul>
+          </Fragment>
         )
       })}
     </ul>

--- a/src/ui/invoice/notes.tsx
+++ b/src/ui/invoice/notes.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { format, formatDistance } from 'date-fns'
+import { useCurrentDate } from '~/ui/hooks/use-current-date'
+import { Markdown } from '../markdown'
+
+export function Notes({ notes }: { notes: { value: string; at: Date }[] }) {
+  let now = useCurrentDate()
+
+  return (
+    <ul role="list" className="flex flex-col gap-4">
+      {notes.map((note, idx) => {
+        return (
+          <li key={idx} className="flex flex-col border-l-2 pl-2 dark:border-gray-200/25">
+            <time
+              title={format(note.at, 'PPPpp')}
+              dateTime={format(note.at, 'PPPpp')}
+              className="py-0.5 text-xs leading-5 text-gray-500 dark:text-gray-300"
+            >
+              {formatDistance(note.at, now, { addSuffix: true })}
+            </time>
+            <Markdown className="prose prose-sm dark:prose-invert">{note.value}</Markdown>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/ui/invoice/notes.tsx
+++ b/src/ui/invoice/notes.tsx
@@ -3,12 +3,12 @@
 import { compareAsc, format, formatDistance } from 'date-fns'
 import { Fragment } from 'react'
 import type { Record } from '~/domain/record/record'
+import { classNames } from '~/ui/class-names'
 import { useCurrentDate } from '~/ui/hooks/use-current-date'
+import { useRecord } from '~/ui/hooks/use-record'
+import { useRecordStacks } from '~/ui/hooks/use-record-stacks'
+import { Markdown } from '~/ui/markdown'
 import { match } from '~/utils/match'
-import { classNames } from '../class-names'
-import { useRecord } from '../hooks/use-record'
-import { useRecordStacks } from '../hooks/use-record-stacks'
-import { Markdown } from '../markdown'
 
 export function Notes(props: React.PropsWithChildren<{ records: Record[] }>) {
   let stacks = useRecordStacks()


### PR DESCRIPTION
This PR adds a new feature where you can add internal notes to `Quote`, `Invoice`, `CreditNote` and `Receipt`.

On each builder there is a new `.internal.note()` function that accepts the note as a `string` and a `date` as the second argument.

E.g.:

```ts
let invoice = new InvoiceBuilder()
  .internal.note('The note', '2023-01-01')
  .build()
```

The date can also be a string and will be parsed into a `Date` object.

The value will be rendered as markdown, so you can use markdown syntax in the note.

Note, these are **internal** notes and are not visible to the client.
